### PR TITLE
Add Guides section with setup and comparison guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [Sharing](#sharing)
 - [Distribution](#distribution)
 - [Home Automation](#home-automation)
+- [Guides](#guides)
   
 ## CLI Tools
 
@@ -59,6 +60,13 @@
 ## Home Automation
 
 - [Immich Home Assistant](https://github.com/outadoc/immich-home-assistant) - Home Assistant component to display random pictures from your Immich library on dashboards and smart displays.
+
+
+## Guides
+
+- [How to Self-Host Immich with Docker Compose](https://selfhosting.sh/apps/immich/) - Complete setup guide covering installation, configuration, and external library management.
+- [Immich vs PhotoPrism](https://selfhosting.sh/compare/immich-vs-photoprism/) - Detailed comparison of features, performance, and use cases.
+- [Immich vs Google Photos](https://selfhosting.sh/compare/immich-vs-google-photos/) - Side-by-side comparison for users considering migrating from Google Photos.
 
 ## Contributing
 


### PR DESCRIPTION
Adds a **Guides** section to the awesome list with community-created setup and comparison guides for Immich:

- **How to Self-Host Immich with Docker Compose** — Complete setup guide covering installation, configuration, and external library management
- **Immich vs PhotoPrism** — Detailed comparison of features, performance, and use cases
- **Immich vs Google Photos** — Side-by-side comparison for users considering migrating from Google Photos

Also adds the Guides entry to the Contents section for navigation.

These are detailed, independent guides published on selfhosting.sh — a self-hosting documentation site covering 1,500+ guides across 300+ apps. Happy to adjust the format or add/remove entries per your preferences.