### PR TITLE
Add Darkroom Log to Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 - [Immich Public Proxy](https://github.com/alangrainger/immich-public-proxy) - Share your Immich photos and albums in a safe way without exposing your Immich instance to the public.
 - [Immich Drop Uploader](https://github.com/Nasogaa/immich-drop) - A tiny, zero-login web app for collecting photos/videos from anyone into your Immich server.
 - [Immich Book](https://github.com/ch1bo/immich-book) - Create beautiful photo books from your Immich albums.
+- [Darkroom Log](https://github.com/jaapjan14/darkroom-log) - Browse, sort, and share your Immich albums and library as branded public galleries, with sort-by-date inside albums (missing from Immich's native UI) and a Ken Burns slideshow with music.
   
 ## Distribution
 


### PR DESCRIPTION
Adds [Darkroom Log](https://github.com/jaapjan14/darkroom-log) to the Sharing section.

A self-hosted web app for browsing, sorting, and sharing your Immich albums and library. Notable for Immich users: sort-by-date *inside* an album (taken or upload date), which the native Immich UI doesn't offer, plus branded public album galleries (without exposing your Immich instance) and a Ken Burns slideshow with music. PWA, mobile-optimized, A+ security headers.