### PR TITLE
Add Slyde to Slideshow & Display

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 
 - [ImmichFrame](https://github.com/3rob3/ImmichFrame) - Run an Immich slideshow in a photo frame.
 - [Immich Kiosk](https://github.com/damongolding/immich-kiosk) - Lightweight slideshow to run on kiosk devices and browsers.
+- [Slyde](https://github.com/SlyWombat/slyde) - Pushes Immich photos to digital photo frames — incl. reviving the discontinued Memento Smart Frame over a reverse-engineered LAN protocol, no cloud.
 - [Immich Android TV](https://github.com/giejay/Immich-Android-TV) - Unofficial Immich Android TV app.
 - [Immich Gallery](https://github.com/mensadilabs/Immich-Gallery) - Native Apple TV app with grid view, people recognition, albums, slideshow mode, and multi-user support.
 


### PR DESCRIPTION
Adds [Slyde](https://github.com/SlyWombat/slyde) under **Slideshow & Display**.

Slyde is a self-hosted, MIT-licensed hub that pushes photos from your Immich library to physical digital photo frames — most notably **reviving the discontinued Memento Smart Frame** over a reverse-engineered LAN protocol (no cloud, no account). It sources from Immich **one-way and read-only** (never writes to your library), and also includes a Raspberry Pi soft-frame mode.

Fits alongside ImmichFrame / Immich Kiosk as another way to display your Immich photos on a frame. Thanks for maintaining the list!