### PR TITLE
Add Picture Frame to Slideshow & Display

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - [Immich Kiosk](https://github.com/damongolding/immich-kiosk) - Lightweight slideshow to run on kiosk devices and browsers.
 - [Immich Android TV](https://github.com/giejay/Immich-Android-TV) - Unofficial Immich Android TV app.
 - [Immich Gallery](https://github.com/mensadilabs/Immich-Gallery) - Native Apple TV app with grid view, people recognition, albums, slideshow mode, and multi-user support.
+- [Picture Frame](https://github.com/MateEke/picture-frame) - Self-hosted Raspberry Pi photo frame for Immich albums, with motion-aware screen power and Home Assistant control.
 
 ## Optimization
 


### PR DESCRIPTION
Self-hosted Raspberry Pi digital photo frame with native Immich album sync.

Adds to Slideshow & Display alongside ImmichFrame and Immich Kiosk.

Differentiators: runs on a Pi Zero with smooth crossfades, motion-aware screen blanking, and two-way Home Assistant/MQTT control.