### PR TITLE
Add Immich Trip Albummer to Media Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [Immich Face To Album](https://github.com/romainrbr/immich-face-to-album) - Sync all photos belonging to one or more detected faces into an existing Immich album
 - [Immich MediaKit](https://github.com/RazgrizHsu/immich-mediakit) - Extension toolkit enabling advanced management capabilities through AI-powered similarity detection and duplicate management.
 - [Immich Auto Stack](https://github.com/tenekev/immich-auto-stack) - Python script that automatically stacks together photos based on configurable criteria like filename and capture time.
+- [Immich Trip Albummer](https://github.com/sophie4869/immich-trip-albums) - Python CLI that clusters photos and videos taken away from home into one album per trip. Deterministic, dry-run by default, and idempotent on re-runs.
 
 ## Slideshow & Display
 


### PR DESCRIPTION
Adds [Immich Trip Albummer](https://github.com/sophie4869/immich-trip-albums) under **Media Management**.

It's a small Python CLI that scans an Immich library, finds photos/videos taken away from home, clusters them into trips (by time gaps and country changes), and creates one album per trip. It's deterministic, dry-run by default, and idempotent on re-runs (albums are identified by a marker in the description, so renames and re-runs are safe).

The core CLI uses no AI, but it's designed to pair with an AI coding agent (e.g. Claude Code) as an optional human-in-the-loop review step before you apply: the agent runs the dry run, reads the plan back to you, and can both suggest better trip names and adjust the automatic merge/split (trip-boundary) decisions — you approve, then it applies.

Single-line addition, format matches the existing Media Management entries.