### PR TITLE
Add Immich Atlas to Media Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 ## Media Management
 
 - [Immich Power Tools](https://github.com/varun-raj/immich-power-tools) - Power tools for organizing your Immich library.
+- [Immich Atlas](https://github.com/GuiMartins/immich-atlas) - Read-only storage & library analytics dashboard: disk usage by folder, album/people sizes, largest videos, growth over time, all auto-refreshing.
 - [Immich Face To Album](https://github.com/romainrbr/immich-face-to-album) - Sync all photos belonging to one or more detected faces into an existing Immich album
 - [Immich MediaKit](https://github.com/RazgrizHsu/immich-mediakit) - Extension toolkit enabling advanced management capabilities through AI-powered similarity detection and duplicate management.
 - [Immich Auto Stack](https://github.com/tenekev/immich-auto-stack) - Python script that automatically stacks together photos based on configurable criteria like filename and capture time.


### PR DESCRIPTION
[Immich Atlas](https://github.com/GuiMartins/immich-atlas) is a read-only storage & library analytics dashboard for Immich — disk usage by folder, album/people sizes, largest videos (sortable by size or duration), growth over time across refreshes, and per-user usage on multi-user servers. Single tiny zero-dependency container, auto-refreshing, first-run setup entirely from the web UI.

Added under Media Management, next to Immich Power Tools since both are library-organization-adjacent, though Atlas is read-only/dashboard-focused rather than bulk-editing.