### PR TITLE
Add Immich Shuttle to Import/Export Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - [Lightroom Publisher: mi.Immich.Publisher](https://github.com/midzelis/mi.Immich.Publisher) - Lightroom plugin to publish photos from Lightroom collections to Immich albums.
 - [Lightroom Immich Plugin: lrc-immich-plugin](https://github.com/bmachek/lrc-immich-plugin) - Lightroom plugin to publish and export photos from Lightroom to Immich. Import from Immich to Lightroom is also supported.
 - [Obsidian Immich Picker](https://github.com/eikowagenknecht/obsidian-immich-picker) - Obsidian plugin to browse and insert photos from your Immich library into notes.
+- [Immich Shuttle](https://github.com/enieuwy/immich-shuttle) - Cross-platform desktop app to import photos and videos into Immich from folders or removable media (SD cards, USB drives) with a point-and-click UI, album selection, and live import progress.
 
 ## Media Management
 


### PR DESCRIPTION
Adds [Immich Shuttle](https://github.com/enieuwy/immich-shuttle) to the Import/Export Tools section.

Immich Shuttle is a cross-platform (macOS/Linux/Windows) desktop app for importing photos and videos into Immich from folders or removable media (SD cards, USB drives). It puts a point-and-click UI over immich-go — the tool already listed under CLI Tools — adding removable-media detection, album selection/creation, and a live import queue with progress, throughput, and duplicate/error stats. Aimed at people who prefer a GUI over the command line.

- License: MIT
- Built with Tauri v2 + Svelte 5; prebuilt binaries for macOS/Linux/Windows on Releases.